### PR TITLE
Avoid 3rd party helper naming collision

### DIFF
--- a/addon/templates/components/button-basic.hbs
+++ b/addon/templates/components/button-basic.hbs
@@ -1,5 +1,5 @@
 {{#if hasIcon}}
-    {{fa-icon icon class="action-button-icon"}}
+    {{fa-icon this.icon class="action-button-icon"}}
 {{/if}}
 {{#if (not iconBtn)}}
     {{#if label}}

--- a/addon/templates/components/button-basic.hbs
+++ b/addon/templates/components/button-basic.hbs
@@ -1,4 +1,7 @@
 {{#if hasIcon}}
+    {{!-- we need to explicity reference this.propName here --}}
+    {{!-- to avoid a naming collision with a 3rd party addon --}}
+    {{!-- that has a helper named "icon" --}}
     {{fa-icon this.icon class="action-button-icon"}}
 {{/if}}
 {{#if (not iconBtn)}}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gavant-ember-button-basic",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "An extensible button component with a myriad of attributes and config options.",
   "author": "Gavant Software, Inc.",
   "repository": "https://github.com/Gavant/gavant-ember-button-basic",


### PR DESCRIPTION
Workaround for issue caused by ember-leaftlet's inclusion of a helper called `icon`, which collides with the `icon` component property, as global helper's take precendence over property names in the ember resolver.

see: https://github.com/miguelcobain/ember-leaflet/issues/175

cc @miguelcobain